### PR TITLE
Fix incorrect FindAsync usage

### DIFF
--- a/Infrastructure/Services/DashboardDal.cs
+++ b/Infrastructure/Services/DashboardDal.cs
@@ -146,7 +146,7 @@ namespace Infrastructure.Services
             .ToListAsync(ct);
 
         public async Task<AccountsPayable?> GetApAsync(int id, CancellationToken ct = default) =>
-            await _db.ApReports.FindAsync([id, ct]);
+            await _db.ApReports.FindAsync(new object?[] { id }, ct);
 
         public async Task<int> UpdateApAsync(AccountsPayable item, CancellationToken ct = default)
         {


### PR DESCRIPTION
## Summary
- fix usage of `FindAsync` to pass cancellation token properly in `DashboardDal`

## Testing
- `dotnet build --nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472da6675c832f98a6f1e1237188d9