### PR TITLE
Implement onboarding create and edit flow

### DIFF
--- a/API/Controllers/OnboardingController.cs
+++ b/API/Controllers/OnboardingController.cs
@@ -16,6 +16,23 @@ namespace API.Controllers
         [HttpGet("{id:int}")]       // GET /api/onboarding/5
         public async Task<IActionResult> GetOne(int id)
             => (await _svc.GetAsync(id)) is { } o ? Ok(o) : NotFound();
+
+        [HttpPost]
+        public async Task<ActionResult<Domain.Entities.Onboarding>> Create(Domain.Entities.Onboarding dto)
+        {
+            var created = await _svc.CreateAsync(dto);
+            if (created is null)
+                return BadRequest("Could not create onboarding.");
+            return CreatedAtAction(nameof(GetOne), new { id = created.OnboardingId }, created);
+        }
+
+        [HttpPut("{id:int}")]
+        public async Task<IActionResult> Update(int id, Domain.Entities.Onboarding dto)
+        {
+            if (id != dto.OnboardingId)
+                return BadRequest();
+            return await _svc.UpdateAsync(dto) ? NoContent() : NotFound();
+        }
     }
 
 }

--- a/Application/Interfaces/IDashboardDal.cs
+++ b/Application/Interfaces/IDashboardDal.cs
@@ -32,5 +32,7 @@ namespace Application.Interfaces.DAL
         // Onboarding
         Task<IReadOnlyList<Onboarding>> GetOnboardingsAsync();
         Task<Onboarding?> GetOnboardingAsync(int id);
+        Task<Onboarding> AddAsync(Onboarding ob);
+        Task<bool> UpdateAsync(Onboarding ob);
     }
 }

--- a/Application/Interfaces/IOnboardingService.cs
+++ b/Application/Interfaces/IOnboardingService.cs
@@ -11,5 +11,8 @@ namespace Application.Interfaces
     {
         Task<IReadOnlyList<Onboarding>> GetAllAsync();
         Task<Onboarding?> GetAsync(int id);
+
+        Task<Onboarding?> CreateAsync(Onboarding entity);
+        Task<bool> UpdateAsync(Onboarding entity);
     }
 }

--- a/Application/Services/OnboardingService.cs
+++ b/Application/Services/OnboardingService.cs
@@ -16,5 +16,11 @@ namespace Application.Services
 
         public Task<IReadOnlyList<Onboarding>> GetAllAsync() => _dal.GetOnboardingsAsync();
         public Task<Onboarding?> GetAsync(int id) => _dal.GetOnboardingAsync(id);
+
+        public Task<Onboarding?> CreateAsync(Onboarding entity)
+            => _dal.AddAsync(entity);
+
+        public Task<bool> UpdateAsync(Onboarding entity)
+            => _dal.UpdateAsync(entity);
     }
 }

--- a/Infrastructure/Services/DashboardDal.cs
+++ b/Infrastructure/Services/DashboardDal.cs
@@ -179,6 +179,27 @@ namespace Infrastructure.Services
                .AsNoTracking()
                .FirstOrDefaultAsync(o => o.OnboardingId == id);
 
+        public async Task<Onboarding> AddAsync(Onboarding ob)
+        {
+            _db.Onboardings.Add(ob);
+            await _db.SaveChangesAsync();
+            return ob;
+        }
+
+        public async Task<bool> UpdateAsync(Onboarding ob)
+        {
+            // update master
+            _db.Onboardings.Update(ob);
+            foreach (var f in ob.Fields)
+            {
+                if (f.Id == 0)
+                    _db.OnboardingFieldData.Add(f);
+                else
+                    _db.OnboardingFieldData.Update(f);
+            }
+            return await _db.SaveChangesAsync() > 0;
+        }
+
         public async Task<TodoTask?> CreateTodoAsync(TodoTask dto)
         {
             _db.ToDoTasks.Add(dto);

--- a/Presentation/Controllers/OnboardingController.cs
+++ b/Presentation/Controllers/OnboardingController.cs
@@ -57,5 +57,61 @@ namespace Presentation.Controllers
             var ob = await response.Content.ReadFromJsonAsync<Onboarding>();
             return ob is null ? NotFound() : View(ob);
         }
+
+        [HttpGet("create")]
+        public IActionResult Create()
+        {
+            ViewBag.FormAction = "Create";
+            return View(new Onboarding { CreatedDateUtc = DateTime.UtcNow });
+        }
+
+        [HttpPost("create")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create(Onboarding dto)
+        {
+            if (!ModelState.IsValid)
+            {
+                ViewBag.FormAction = "Create";
+                return View(dto);
+            }
+
+            var resp = await _api.PostAsJsonAsync("api/onboarding", dto);
+            if (resp.IsSuccessStatusCode)
+                return RedirectToAction("Index");
+
+            var msg = await resp.Content.ReadAsStringAsync();
+            ModelState.AddModelError("", string.IsNullOrWhiteSpace(msg) ? "Failed to create onboarding." : msg);
+            ViewBag.FormAction = "Create";
+            return View(dto);
+        }
+
+        [HttpGet("edit/{id:int}")]
+        public async Task<IActionResult> Edit(int id)
+        {
+            var row = await _api.GetFromJsonAsync<Onboarding>($"api/onboarding/{id}");
+            if (row == null) return NotFound();
+            ViewBag.FormAction = $"Edit/{id}";
+            return View(row);
+        }
+
+        [HttpPost("edit/{id:int}")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(int id, Onboarding dto)
+        {
+            if (!ModelState.IsValid)
+            {
+                ViewBag.FormAction = $"Edit/{id}";
+                return View(dto);
+            }
+
+            var resp = await _api.PutAsJsonAsync($"api/onboarding/{id}", dto);
+            if (resp.IsSuccessStatusCode)
+                return RedirectToAction("Index");
+
+            var msg = await resp.Content.ReadAsStringAsync();
+            ModelState.AddModelError("", string.IsNullOrWhiteSpace(msg) ? "Failed to update onboarding." : msg);
+            ViewBag.FormAction = $"Edit/{id}";
+            return View(dto);
+        }
     }
 }

--- a/Presentation/Views/Onboarding/Create.cshtml
+++ b/Presentation/Views/Onboarding/Create.cshtml
@@ -1,0 +1,7 @@
+@model Domain.Entities.Onboarding
+@{
+    ViewBag.Title = "Create Onboarding";
+    ViewBag.FormAction = "Create";
+}
+<h2>Create Onboarding</h2>
+<partial name="_OnboardingForm" model="Model" />

--- a/Presentation/Views/Onboarding/Edit.cshtml
+++ b/Presentation/Views/Onboarding/Edit.cshtml
@@ -1,0 +1,7 @@
+@model Domain.Entities.Onboarding
+@{
+    ViewBag.Title = $"Edit Onboarding #{Model.OnboardingId}";
+    ViewBag.FormAction = $"Edit/{Model.OnboardingId}";
+}
+<h2>Edit Onboarding #@Model.OnboardingId</h2>
+<partial name="_OnboardingForm" model="Model" />

--- a/Presentation/Views/Onboarding/Index.cshtml
+++ b/Presentation/Views/Onboarding/Index.cshtml
@@ -2,6 +2,9 @@
     ViewBag.Title = "On-Boarding";
 }
 <h2 class="mb-3">On-Boarding</h2>
+<a asp-action="Create" class="btn btn-success mb-3">
+    <i class="bi bi-plus-lg"></i> Create
+</a>
 <table id="tblOb" class="table table-striped w-100"></table>
 
 @section Scripts {

--- a/Presentation/Views/Shared/_OnboardingForm.cshtml
+++ b/Presentation/Views/Shared/_OnboardingForm.cshtml
@@ -1,0 +1,95 @@
+@model Domain.Entities.Onboarding
+@{
+    string[] labels = new[] {
+        "Task Order #",
+        "Client/Agency Name (from Onboarding letter)",
+        "Form-2/Form-B",
+        "Insert the agency Name from Form-1/Form",
+        "Job Title",
+        "Work Location",
+        "Project/Program Name",
+        "Name of Recruiter",
+        "Date of confirmation",
+        "Actual Start Date (per client work order)",
+        "End Date (Per client work order)",
+        "Expected onboarding Date",
+        "DOB",
+        "Name of the consultant",
+        "Current Location",
+        "Phone Number of the consultant",
+        "Email address of the consultant",
+        "Hiring Term (W-2, 1099, C2C)",
+        "Mailing address of the consultant",
+        "Onboarding Letter from the client (received)",
+        "Bill Rate (rate from the client)",
+        "Finger Printing to be done (Yes/NO)",
+        "Background Check (Yes or No)",
+        "Onboarding email to the candidate",
+        "Remote log in credentials to the consultant",
+        "Non-Compete Agreement/BNB Consultant Doc-1",
+        "Original SSN and VISA document Needed",
+        "I-9",
+        "Core Form/NDA Form",
+        "Telecommuting",
+        "To Track the Submission (CJIS)",
+        "Name of the vendor, if any",
+        "Phone number of the POC at vendor",
+        "Email address of the POC at vendor",
+        "Pay Rate (Rate to the Vendor/Consultant)",
+        "FED ID of the vendor",
+        "Address of the vendor",
+        "MSA/Employment Letter",
+        "Work Order",
+        "COI",
+        "Billing Terms (Net 30 or Net 45)",
+        "Onboarding email to the vendor",
+        "Upload Payroll information on CEIPAL",
+        "W9/I-9",
+        "Timesheets (Weekly, LATS, Monthly, or Fortnightly)",
+        "Tracking/Arrival/Joining details of the consultant",
+        "* All verifications to be done by the support team",
+        "All files uploaded in DB",
+        "Engagement Length in Months",
+        "Visa/Passport #",
+        "Type of Visa"
+    };
+    var dict = Model.Fields.ToDictionary(f => f.FieldName!, f => f);
+}
+<form asp-action="@ViewBag.FormAction" method="post">
+    @if (Model.OnboardingId != 0)
+    {
+        <input type="hidden" asp-for="OnboardingId" />
+    }
+    <div class="mb-3">
+        <label asp-for="CandidateName" class="form-label"></label>
+        <input asp-for="CandidateName" class="form-control" />
+    </div>
+    <table class="table table-bordered">
+        <thead>
+            <tr><th>Item</th><th>Owner</th><th>Value</th><th>Notes</th><th>Date</th></tr>
+        </thead>
+        <tbody>
+        @for (int i = 0; i < labels.Length; i++)
+        {
+            var lbl = labels[i];
+            dict.TryGetValue(lbl, out var f);
+            <tr>
+                <td>
+                    @lbl
+                    <input type="hidden" name="Fields[@i].FieldName" value="@lbl" />
+                    <input type="hidden" name="Fields[@i].Id" value="@(f?.Id ?? 0)" />
+                    <input type="hidden" name="Fields[@i].OnboardingId" value="@Model.OnboardingId" />
+                </td>
+                <td><input class="form-control" name="Fields[@i].Owner" value="@f?.Owner" /></td>
+                <td><input class="form-control" name="Fields[@i].Value" value="@f?.Value" /></td>
+                <td><input class="form-control" name="Fields[@i].Notes" value="@f?.Notes" /></td>
+                <td><input class="form-control" name="Fields[@i].Date" type="date" value="@f?.Date?.ToString("yyyy-MM-dd")" /></td>
+            </tr>
+        }
+        </tbody>
+    </table>
+    <div class="mt-3">
+        <button class="btn btn-success" type="submit">Save</button>
+        <a asp-action="Index" class="btn btn-secondary">Cancel</a>
+    </div>
+</form>


### PR DESCRIPTION
## Summary
- extend onboarding service/dal for create & update
- expose POST and PUT in API onboarding controller
- add create/edit actions and views for onboarding UI
- provide shared `_OnboardingForm` partial with dynamic rows
- show a create button on the onboarding index page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684735bb28b0832fb283fa8c5411cb78